### PR TITLE
Fix #21: Remove dependency of underscore library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## _Next_
+### Added
+- Removed dependency to underscore
+
 ## [0.1.6] - 2017-02-27
 ### Fixed
 - Fixed incorrect information in README section that talks about path/routing

--- a/nodePCCC.js
+++ b/nodePCCC.js
@@ -32,7 +32,6 @@
 // only applications.
 
 var net = require("net");
-var _ = require("underscore");
 var util = require("util");
 var effectiveDebugLevel = 0; // intentionally global, shared between connections
 
@@ -339,7 +338,7 @@ NodePCCC.prototype.writeItems = function(arg, value, cb) {
 		if (typeof(self.instantWriteBlockList[self.instantWriteBlockList.length - 1]) !== "undefined") {
 			self.instantWriteBlockList[self.instantWriteBlockList.length - 1].writeValue = value;
 		}
-	} else if (_.isArray(arg) && _.isArray(value) && (arg.length == value.length)) {
+	} else if (Array.isArray(arg) && Array.isArray(value) && (arg.length == value.length)) {
 		for (i = 0; i < arg.length; i++) {
 			if (typeof arg[i] === "string") {
 				self.instantWriteBlockList.push(stringToSLCAddr(self.translationCB(arg[i]), arg[i]));
@@ -389,7 +388,7 @@ NodePCCC.prototype.addItemsNow = function(arg) {
 	addItemsFlag = false;
 	if (typeof arg === "string") { 
 		self.polledReadBlockList.push(stringToSLCAddr(self.translationCB(arg), arg));
-	} else if (_.isArray(arg)) {
+	} else if (Array.isArray(arg)) {
 		for (i = 0; i < arg.length; i++) {
 			if (typeof arg[i] === "string") {
 				self.polledReadBlockList.push(stringToSLCAddr(self.translationCB(arg[i]), arg[i]));
@@ -427,7 +426,7 @@ NodePCCC.prototype.removeItemsNow = function(arg) {
 				self.polledReadBlockList.splice(i, 1);
 			}
 		}
-	} else if (_.isArray(arg)) {
+	} else if (Array.isArray(arg)) {
 		for (i = 0; i < self.polledReadBlockList.length; i++) {
 			for (j = 0; j < arg.length; j++) {
 				if (self.polledReadBlockList[i].addr === self.translationCB(arg[j])) {
@@ -1951,7 +1950,7 @@ function bufferizePCCCItem(theItem) {
 function isQualityOK(obj) {
 	if (typeof obj === "string") { 
 		if (obj !== 'OK') { return false; } 
-	} else if (_.isArray(obj)) {
+	} else if (Array.isArray(obj)) {
 		for (i = 0; i < obj.length; i++) {
 			if (typeof obj[i] !== "string" || obj[i] !== 'OK') { return false; }
 		}

--- a/package.json
+++ b/package.json
@@ -23,8 +23,5 @@
   },
   "main": "nodePCCC.js",
   "license": "MIT",
-  "dependencies": {
-    "underscore": "1.4.x"
-  },
   "engine": "node 0.10.x"
 }


### PR DESCRIPTION
Fixes #21 by removing the dependency on underscore by replacing the array checks with javascript's built-in `Array.isArray()`