### PR TITLE
Fix ghost writings

### DIFF
--- a/nodePCCC.js
+++ b/nodePCCC.js
@@ -561,6 +561,9 @@ NodePCCC.prototype.prepareWritePacket = function() {
 		return undefined;
 	}
 	
+	// BUGFIX: clear old writing requests!
+	self.globalWriteBlockList.splice(0);
+	
 	// At this time we do not do write optimizations.  
 	// The reason for this is it is would cause numerous issues depending how the code was written in the PLC.
 	// If we write B3:0/0 and B3:0/1 then to optimize we would have to write all of B3:0, which also writes /2, /3...


### PR DESCRIPTION
The array self.globalWriteBlockList need to be cleaned in order to create new writing packets properly. Otherwise, you may get wrong things written in wrong places.
For instance, if you call writeItems with 5 items, they will be written, but if call it again with only 3, they will be written and the last two items from the first request will be written as well, again.